### PR TITLE
Fix falloffmap feature in E20 and E21

### DIFF
--- a/Proc Gen E20/Assets/Scripts/HeightMapGenerator.cs
+++ b/Proc Gen E20/Assets/Scripts/HeightMapGenerator.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public static class HeightMapGenerator {
 
+	static float[,] falloffMap;
+
 	public static HeightMap GenerateHeightMap(int width, int height, HeightMapSettings settings, Vector2 sampleCentre) {
 		float[,] values = Noise.GenerateNoiseMap (width, height, settings.noiseSettings, sampleCentre);
 
@@ -12,9 +14,15 @@ public static class HeightMapGenerator {
 		float minValue = float.MaxValue;
 		float maxValue = float.MinValue;
 
+		if (settings.useFalloff) {
+			if (falloffMap == null) {
+				falloffMap = FalloffGenerator.GenerateFalloffMap (width);
+			}
+		}
+
 		for (int i = 0; i < width; i++) {
 			for (int j = 0; j < height; j++) {
-				values [i, j] *= heightCurve_threadsafe.Evaluate (values [i, j]) * settings.heightMultiplier;
+				values [i, j] *= heightCurve_threadsafe.Evaluate (values [i, j] - (settings.useFalloff ? falloffMap[i, j] : 0)) * settings.heightMultiplier;
 
 				if (values [i, j] > maxValue) {
 					maxValue = values [i, j];

--- a/Proc Gen E21/Assets/Scripts/HeightMapGenerator.cs
+++ b/Proc Gen E21/Assets/Scripts/HeightMapGenerator.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public static class HeightMapGenerator {
 
+	static float[,] falloffMap;
+
 	public static HeightMap GenerateHeightMap(int width, int height, HeightMapSettings settings, Vector2 sampleCentre) {
 		float[,] values = Noise.GenerateNoiseMap (width, height, settings.noiseSettings, sampleCentre);
 
@@ -12,9 +14,15 @@ public static class HeightMapGenerator {
 		float minValue = float.MaxValue;
 		float maxValue = float.MinValue;
 
+		if (settings.useFalloff) {
+			if (falloffMap == null) {
+				falloffMap = FalloffGenerator.GenerateFalloffMap (width);
+			}
+		}
+
 		for (int i = 0; i < width; i++) {
 			for (int j = 0; j < height; j++) {
-				values [i, j] *= heightCurve_threadsafe.Evaluate (values [i, j]) * settings.heightMultiplier;
+				values [i, j] *= heightCurve_threadsafe.Evaluate (values [i, j] - (settings.useFalloff ? falloffMap[i, j] : 0)) * settings.heightMultiplier;
 
 				if (values [i, j] > maxValue) {
 					maxValue = values [i, j];


### PR DESCRIPTION
The falloffmap feature was broken/removed during the refactor for E20
and E21. This simply adds it back to those codebases.