### PR TITLE
Pass in heightScale of the preview Mesh GameObject

### DIFF
--- a/Proc Gen E08/Assets/Scripts/MapGenerator.cs
+++ b/Proc Gen E08/Assets/Scripts/MapGenerator.cs
@@ -41,7 +41,7 @@ public class MapGenerator : MonoBehaviour {
 		} else if (drawMode == DrawMode.ColourMap) {
 			display.DrawTexture (TextureGenerator.TextureFromColourMap (mapData.colourMap, mapChunkSize, mapChunkSize));
 		} else if (drawMode == DrawMode.Mesh) {
-			display.DrawMesh (MeshGenerator.GenerateTerrainMesh (mapData.heightMap, meshHeightMultiplier, meshHeightCurve, levelOfDetail), TextureGenerator.TextureFromColourMap (mapData.colourMap, mapChunkSize, mapChunkSize));
+			display.DrawMesh (MeshGenerator.GenerateTerrainMesh (mapData.heightMap, meshHeightMultiplier, meshHeightCurve, levelOfDetail, display.meshFilter.transform.localScale.x), TextureGenerator.TextureFromColourMap (mapData.colourMap, mapChunkSize, mapChunkSize));
 		}
 	}
 


### PR DESCRIPTION
After Sebastian changes the TerrainChunks from a primitive to a regular GameObject, he stops setting the scale; meaning it goes from (10, 1, 10) to (1, 1, 1). This is correct, but causes the user to instinctively tone-down the heightMultiplier (from 125 to 25 in my case), but the scale of the Mesh GameObject is sitll (10, 1, 10).
These changes will allow the scale of the preview GameObject to be adaptive and still be representative of what will be generated at runtime.
Note: This all assumes that the plane is a square (x and z are the same), which is why only the localScale.x is used.